### PR TITLE
Clone array callback

### DIFF
--- a/lib/callback-manager.js
+++ b/lib/callback-manager.js
@@ -179,7 +179,7 @@ var CallbackManager = Class.$extend({
                 callbacks = lodash.concat(callbacks, lodash.filter(this.$data.callbacks[evName], filter[i]));
             }
         } else {
-            callbacks = this.$data.callbacks[evName];
+            callbacks = lodash.clone(this.$data.callbacks[evName]);
         }
 
         if (orderBy) {


### PR DESCRIPTION
If I remove an event callback in a callback, the second callback is not called.