### PR TITLE
Use sentry scope to capture exception

### DIFF
--- a/lib/debug.js
+++ b/lib/debug.js
@@ -185,12 +185,12 @@ var Debug = Class.$extend({
         if (!this.$data._caughtMessages[type][id]) {
             this.$data._caughtMessages[type][id] = true;
 
-            Sentry.captureException(error, {
-                level: type,
-                logger: "obsidian/debug",
-                tags: tags,
-                extra: extra
-            });
+            Sentry.configureScope( (scope) => {
+                scope.setLevel(type);
+                scope.setTags(tags)
+                scope.setExtras(extra);
+                Sentry.captureException(error);
+            })
         }
     },
 

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -185,7 +185,7 @@ var Debug = Class.$extend({
         if (!this.$data._caughtMessages[type][id]) {
             this.$data._caughtMessages[type][id] = true;
 
-            Sentry.configureScope((scope) => {
+            Sentry.withScope((scope) => {
                 scope.setLevel(type);
                 scope.setTags(tags);
                 scope.setExtras(extra);

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -187,7 +187,7 @@ var Debug = Class.$extend({
 
             Sentry.configureScope( (scope) => {
                 scope.setLevel(type);
-                scope.setTags(tags)
+                scope.setTags(tags);
                 scope.setExtras(extra);
                 Sentry.captureException(error);
             })

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -185,12 +185,12 @@ var Debug = Class.$extend({
         if (!this.$data._caughtMessages[type][id]) {
             this.$data._caughtMessages[type][id] = true;
 
-            Sentry.configureScope( (scope) => {
+            Sentry.configureScope((scope) => {
                 scope.setLevel(type);
                 scope.setTags(tags);
                 scope.setExtras(extra);
                 Sentry.captureException(error);
-            })
+            });
         }
     },
 


### PR DESCRIPTION
By using @sentry/browser v5 instead of raven-js v3, Sentry capture API has changed

Now, we have to use Sentry scope for enriching error data: https://docs.sentry.io/enriching-error-data/context/?platform=javascript

Here is an example of an event with thoses changes : https://sentry.io/organizations/wanadev-kz/issues/1272080092/?project=1380986&query=is%3Aunresolved